### PR TITLE
Funding acknowledgement; missing licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Context Demo "Gazpacho" for Android
+
+(Description, dependencies, how to build, install ...)
+
+## Licence 
+(to be added)
+
+## Funding Acknowledgement
+
+The research leading to these results has received funding from the European
+Union's Seventh Framework Programme (FP7/2007-2013) under grant agreement No.289016
+([Cloud4all](http://www.cloud4all.info/)).


### PR DESCRIPTION
Hi,

I'm adding the standard funding acknowledgement that should be added to any public code repository in Cloud4all.

Please also add a licence (BSD 3-Clause license, MIT License or Apache License 2.0, unless you have a good reason to use something more restrictive such as LGPL).
